### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/aliasfalse/hubot-wikia.png?label=ready&title=Ready)](https://waffle.io/aliasfalse/hubot-wikia)
 # hubot-wikia
 
 ##Most of the links on this page referring to the usage, installation, or api will not function currently.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/aliasfalse/hubot-wikia

This was requested by a real person (user aliasfalse) on waffle.io, we're not trying to spam you.
